### PR TITLE
New diffraction vector indexation updates

### DIFF
--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -199,7 +199,7 @@ class VectorIndexationGenerator():
                  vectors,
                  vector_library):
         if vectors.cartesian is None:
-            ValueError("Cartesian coordinates are required in order to index "
+            raise ValueError("Cartesian coordinates are required in order to index "
                        "diffraction vectors. Use the get_cartesian_coordinates "
                        "method of DiffractionVectors to obtain these.")
         else:

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -224,6 +224,8 @@ class VectorIndexationGenerator():
         angle_tol : float
             The maximum absolute error in inter-vector angle, in units of
             degrees, allowed for indexation.
+        seed_pool_size : int
+            The maximum number of peak pairs to check.
         n_best : int
             The maximum number of good solutions to be retained.
         keys : list
@@ -245,7 +247,7 @@ class VectorIndexationGenerator():
         vectors = self.vectors
         library = self.library
 
-        indexation, rhkls = vectors.map(match_vectors,
+        matched = vectors.cartesian.map(match_vectors,
                                         library=library,
                                         mag_tol=mag_tol,
                                         angle_tol=angle_tol,
@@ -254,7 +256,9 @@ class VectorIndexationGenerator():
                                         keys=keys,
                                         inplace=False,
                                         *args,
-                                        **kwargs)
+                                        **kwargs).data
+        indexation = matched[:, :, 0]
+        rhkls = matched[:, :, 1]
 
         indexation_results = VectorMatchingResults(indexation)
         indexation_results.hkls = rhkls

--- a/pyxem/generators/library_generator.py
+++ b/pyxem/generators/library_generator.py
@@ -127,7 +127,7 @@ class DiffractionLibraryGenerator(object):
                     diffraction_library[key] = phase_diffraction_library
 
         # Pass attributes to diffraction library from structure library.
-        diffraction_library.identifiers = structure_library.indentifiers
+        diffraction_library.identifiers = structure_library.identifiers
         diffraction_library.structures = structure_library.structures
 
         return diffraction_library
@@ -197,7 +197,7 @@ class VectorLibraryGenerator(object):
             vector_library[key] = np.array(phase_vectors)
 
         # Pass attributes to diffraction library from structure library.
-        vector_library.identifiers = structure_library.indentifiers
-        vector_library.structures = structure_library.structures
+        vector_library.identifiers = self.structures.identifiers
+        vector_library.structures = self.structures.structures
 
         return vector_library

--- a/pyxem/generators/library_generator.py
+++ b/pyxem/generators/library_generator.py
@@ -188,6 +188,8 @@ class VectorLibraryGenerator(object):
                 # specify hkls and lengths
                 # TODO: This should be updated to reflect systematic absences
                 # associated with the crystal structure.
+                if np.count_nonzero(coordinates[i]) == 0 or np.count_nonzero(coordinates[j]) == 0:
+                    continue
                 hkl1 = indices[i]
                 hkl2 = indices[j]
                 len1 = distances[i]

--- a/pyxem/generators/library_generator.py
+++ b/pyxem/generators/library_generator.py
@@ -85,16 +85,15 @@ class DiffractionLibraryGenerator(object):
         diffraction_library = DiffractionLibrary()
         # The electron diffraction calculator to do simulations
         diffractor = self.electron_diffraction_calculator
-        structure_library = structure_library.struct_lib
         # Iterate through phases in library.
-        for key in structure_library.keys():
+        for key in structure_library.struct_lib.keys():
             phase_diffraction_library = dict()
-            structure = structure_library[key][0]
+            structure = structure_library.struct_lib[key][0]
             a, b, c = structure.lattice.a, structure.lattice.b, structure.lattice.c
             alpha = structure.lattice.alpha
             beta = structure.lattice.beta
             gamma = structure.lattice.gamma
-            orientations = structure_library[key][1]
+            orientations = structure_library.struct_lib[key][1]
             # Iterate through orientations of each phase.
             for orientation in tqdm(orientations, leave=False):
                 _orientation = np.deg2rad(orientation)

--- a/pyxem/libraries/diffraction_library.py
+++ b/pyxem/libraries/diffraction_library.py
@@ -91,9 +91,9 @@ class DiffractionLibrary(dict):
         structure associated with each phase in the library.
     """
 
-    #def __init__(self, *args, **kwargs):
-    #    self.indentifiers = None
-    #    self.structures = None
+    def __init__(self, *args, **kwargs):
+        self.identifiers = None
+        self.structures = None
 
     def get_library_entry(self, phase=None, angle=None):
         """Extracts a single DiffractionLibrary entry.

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -47,6 +47,7 @@ def load_mtex_map(filename):
 
 def _euler2axangle_signal(euler):
     """ Find the magnitude of a rotation"""
+    euler = euler[0]  # TODO: euler is a 1-element ndarray(dtype=object) with a tuple
     return np.array(euler2axangle(euler[0], euler[1], euler[2])[1])
 
 
@@ -110,6 +111,9 @@ class CrystallographicMap(BaseSignal):
         """
         phase_map = self.isig[0].as_signal2D((0, 1))
         phase_map = transfer_navigation_axes(phase_map, self)
+        # TODO: Since vector matching results (and template in the future?) returns
+        # in object form, the isigs inherit it, even though this column is an index
+        phase_map.change_dtype('float')
 
         return phase_map
 
@@ -128,6 +132,9 @@ class CrystallographicMap(BaseSignal):
         eulers.map(_euler2axangle_signal, inplace=True)
         orientation_map = eulers.as_signal2D((0, 1))
         orientation_map = transfer_navigation_axes(orientation_map, self)
+        # TODO: Since vector matching results (and template in the future?) returns
+        # in object form, eulers inherits it
+        orientation_map.change_dtype('float')
 
         return orientation_map
 

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -259,15 +259,21 @@ class DiffractionVectors(BaseSignal):
 
         return crystim
 
-    def get_cartesian_coordinates(self, accelerating_voltage,
+    def get_cartesian_coordinates(self, wavelength, camera_length,
                                   *args, **kwargs):
         """Get cartesian coordinates of the diffraction vectors.
 
         Parameters
         ----------
-        accelerating_voltage : float
-            The electron accelerating voltage at which the data was acquired.
+        wavelength : float
+            The electron wavelength at which the data was acquired.
+        camera_length : float
+            The camera length in meters.
         """
+        # TODO: Might be more consistent to ask for accelerating_voltage,
+        # but that requires importing sim_utils, which creates a circular dependency
         self.cartesian = self.map(detector_to_fourier,
-                                  accelerating_voltage=accelerating_voltage,
+                                  wavelength=wavelength,
+                                  camera_length=camera_length,
+                                  inplace=False,
                                   *args, **kwargs)

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -122,6 +122,7 @@ class VectorMatchingResults(BaseSignal):
 
     def __init__(self, *args, **kwargs):
         BaseSignal.__init__(self, *args, **kwargs)
+        self.axes_manager.set_signal_dimension(0)  # TODO: Correct? The data is dtype object...
         self.vectors = None
         self.hkls = None
 

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -482,7 +482,10 @@ def angle_between_cartesian(a, b):
     angle : float
         Angle between `a` and `b` in radians.
     """
-    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))))
+    determinant = np.linalg.norm(a) * np.linalg.norm(b)
+    if determinant == 0:
+        return 0.0
+    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / determinant)))
 
 
 def rotation_list_stereographic(structure, corner_a, corner_b, corner_c,

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -25,6 +25,7 @@ import collections
 from .atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
 from .lobato_scattering_params import ATOMIC_SCATTERING_PARAMS_LOBATO
 from pyxem.signals.electron_diffraction import ElectronDiffraction
+from pyxem.utils.vector_utils import get_angle_cartesian
 from transforms3d.axangles import axangle2mat
 from transforms3d.euler import mat2euler
 from transforms3d.quaternions import mat2quat, rotate_vector
@@ -469,25 +470,6 @@ def uvtw_to_uvw(uvtw):
     return tuple((int(x / common_factor)) for x in (u, v, w))
 
 
-def angle_between_cartesian(a, b):
-    """Compute the angle between two vectors in a cartesian coordinate system.
-
-    Parameters
-    ----------
-    a, b : array-like with 3 floats
-        The two directions to compute the angle between.
-
-    Returns
-    -------
-    angle : float
-        Angle between `a` and `b` in radians.
-    """
-    determinant = np.linalg.norm(a) * np.linalg.norm(b)
-    if determinant == 0:
-        return 0.0
-    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / determinant)))
-
-
 def rotation_list_stereographic(structure, corner_a, corner_b, corner_c,
                                 inplane_rotations, resolution):
     """Generate a rotation list covering the inverse pole figure specified by
@@ -535,9 +517,9 @@ def rotation_list_stereographic(structure, corner_a, corner_b, corner_c,
     corner_b /= np.linalg.norm(corner_b)
     corner_c /= np.linalg.norm(corner_c)
 
-    angle_a_to_b = angle_between_cartesian(corner_a, corner_b)
-    angle_a_to_c = angle_between_cartesian(corner_a, corner_c)
-    angle_b_to_c = angle_between_cartesian(corner_b, corner_c)
+    angle_a_to_b = get_angle_cartesian(corner_a, corner_b)
+    angle_a_to_c = get_angle_cartesian(corner_a, corner_c)
+    angle_b_to_c = get_angle_cartesian(corner_b, corner_c)
     axis_a_to_b = np.cross(corner_a, corner_b)
     axis_a_to_c = np.cross(corner_a, corner_c)
 
@@ -570,7 +552,7 @@ def rotation_list_stereographic(structure, corner_a, corner_b, corner_c,
         # Then define an axis and a maximum rotation to create a great cicle
         # arc between local_b and local_c. Ensure that this is not a degenerate
         # case where local_b and local_c are coincident.
-        angle_local_b_to_c = angle_between_cartesian(local_b, local_c)
+        angle_local_b_to_c = get_angle_cartesian(local_b, local_c)
         axis_local_b_to_c = np.cross(local_b, local_c)
         if np.count_nonzero(axis_local_b_to_c) == 0:
             # Theta rotation ended at the same position. First position, might

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -42,18 +42,18 @@ def detector_to_fourier(z, wavelength, camera_length):
 
     """
     # specify experimental parameters
+    # TODO: z is a 1-element ndarray(dtype='object') containing the coordinates
+    z = z[0]
     camera_length = np.ones(len(z)) * camera_length
     camera_length = np.reshape(camera_length, (-1, 1))
     # reshape and scale 2D vectors
-    k1 = np.hstack((z, camera_length))
-    k1_norm = np.sqrt(np.diag(k1.dot(k1.T)))
-    k1_norm = k1_norm.reshape((-1, 1)).repeat(3, axis=1)
-    k1 = k1 / k1_norm
-    # Sort third component
-    k0 = np.asarray([0., 0., 1.])
-    k0 = k0.reshape((1, -1)).repeat(z, axis=0)
-    k = 1. / wavelength * (k1 - k0)
-
+    k = np.hstack((z, camera_length))
+    # Compute norm of each row in k1
+    k_norm = np.sqrt(np.sum(k * k, 1))
+    k /= k_norm[:, np.newaxis]
+    # TODO: Why do we subtract 1 (or k_norm before normalizing) from the camera length component (correct?)
+    k[:, 2] -= 1
+    k *= 1 / wavelength
     return k
 
 

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -194,9 +194,7 @@ def get_angle_cartesian(a, b):
     angle : float
         Angle between `a` and `b` in radians.
     """
-    try:
-        angle = math.acos(min(1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))))
-    except BaseException:
-        angle = math.acos(max(-1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))))
-
-    return angle
+    determinant = np.linalg.norm(a) * np.linalg.norm(b)
+    if determinant == 0:
+        return 0.0
+    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / determinant)))

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -117,23 +117,21 @@ def get_rotation_matrix_between_vectors(k1, k2, ref_k1, ref_k2):
         Rotation matrix describing transformation from experimentally measured
         scattering vectors to equivalent reference vectors.
     """
-    ref_nv = np.cross(ref_k1, ref_k2)
-    k_nv = np.cross(k1, k2)
+    ref_plane_normal = np.cross(ref_k1, ref_k2)
+    k_plane_normal = np.cross(k1, k2)
     # avoid 0 degree including angle
-    if min(norm(ref_nv), norm(k_nv)) == 0.:
+    if np.linalg.norm(k_plane_normal) or np.linalg.norm(ref_plane_normal):
         R = np.identity(3)
     else:
-        axis = np.cross(ref_nv, k_nv)
-        angle = np.rad2deg(acos(ref_nv.dot(k_nv) / (norm(ref_nv) * norm(k_nv))))
+        axis = np.cross(ref_plane_normal, k_plane_normal)
+        angle = get_angle_cartesian(ref_plane_normal, k_plane_normal)
         R1 = axangle2mat(axis, angle)
-        # rotate ref_q1,2 plane to q1,2 plane
+        # rotate ref_k1,2 plane to k1,2 plane
         rot_ref_k1, rot_ref_k2 = R1.dot(ref_k1), R1.dot(ref_k2)
-        # avoid math domain error
-        cos1 = max(min(k1.dot(rot_ref_k1) / (np.linalg.norm(rot_ref_k1) * np.linalg.norm(k1)), 1.), -1.)
-        cos2 = max(min(k2.dot(rot_ref_k2) / (np.linalg.norm(rot_ref_k2) * np.linalg.norm(k2)), 1.), -1.)
-        angle1 = np.rad2deg(acos(cos1))
-        angle2 = np.rad2deg(acos(cos2))
-        angle = (angle1 + angle2) / 2.
+        # TODO: can one of the vectors be zero vectors?
+        angle1 = get_angle_cartesian(k1, rot_ref_k1)
+        angle2 = get_angle_cartesian(k2, rot_ref_k2)
+        angle = 0.5 * (angle1 + angle2)
         axis = np.cross(rot_ref_k1, k1)
         R2 = axangle2mat(axis, angle)
         R = R2.dot(R1)

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -26,7 +26,7 @@ from pyxem.utils.sim_utils import get_electron_wavelength, \
     get_vectorized_list_for_atomic_scattering_factors, get_points_in_sphere, \
     simulate_kinematic_scattering, peaks_from_best_template, \
     is_lattice_hexagonal, transfer_navigation_axes, uvtw_to_uvw, \
-    angle_between_cartesian, rotation_list_stereographic
+    rotation_list_stereographic
 
 
 def create_lattice_structure(a, b, c, alpha, beta, gamma):


### PR DESCRIPTION
---
Diffraction vector indexation updates
Continue your work on the new diffraction vector indexation method
---
The code is now running from start to end, but I have several TODOs left, including actually getting reasonable matches. I'm at least missing something in the `detector_to_fourier` (calibration/scaling I think), and there are probably still some mistakes in `VectorIndexationGenerator.index_vectors` that I have not gotten to yet. In the meantime, some questions about the structure:

Should we add some intensity filtering to the sphere points in `VectorLibraryGenerator.get_vector_library`? Currently, the combinatorics makes it impractical to include points with higher index than 2 or 3. Another option is to reduce the list by symmetry.

I'm not sure about changing indexation results to store ndarray(dtype=object) ([phase, np.array((z, x, z)), dict]). It makes some usage code more readable, but it does not behave like flat float arrays. For example, I had to add `z = z[0]` in some of the map functions (e.g. `_euler2axangle_signal`), since the map gives a single-element ndarray(dtype=object), where the element is the array we actually want. It also seems that the result of a map inherits the dtype=object (see `get_phase_map` where I had to change the dtype). Could an option be to add `get_phase`, `get_orientation`, `get_correlation` etc. on the indexation result classes, and keep the pure 2D float arrays internally? I have looked only briefly on the hyperspy map implementation, so there could be a cleaner solution while keeping the object type. Also: Have you used numpy structured arrays? I only testet them briefly, and it seems they have the same problem with the map function and signal indexing.

The `DiffractionVectors.get_cartesian_coordinates` function takes wavelength instead of accelerating voltage. Should we change to beam accelerating voltage like the DiffractionGenerator uses? That would require moving `get_electron_wavelength` from sim_utils (importing it into `diffraction_vectors` creates a circular dependency).


**Work in progress**
Get better results, see TODOs in code.

**Additional context**
PR via here, to eventually update https://github.com/pyxem/pyxem/pull/315.